### PR TITLE
セキュリティ修正: FANZA API IDのハードコード削除

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -44,7 +44,7 @@ DB_NAME=（管理画面で作ったDB名）
 DB_USER=（管理画面で作ったDBユーザー）
 DB_PASS=（設定したパスワード）
 
-FANZA_API_ID=47sPXfBnNCUgVfKabDPy
+FANZA_API_ID=（FANZA APIのAPI ID）
 FANZA_AFFILIATE_ID=（DMMアフィリエイト審査通過後に設定）
 ```
 

--- a/meikan/.env.example
+++ b/meikan/.env.example
@@ -3,5 +3,5 @@ DB_NAME=video_meikan
 DB_USER=root
 DB_PASS=
 
-FANZA_API_ID=47sPXfBnNCUgVfKabDPy
+FANZA_API_ID=your_api_id_here
 FANZA_AFFILIATE_ID=your_affiliate_id_here

--- a/meikan/batch/fetch_actress_profiles.php
+++ b/meikan/batch/fetch_actress_profiles.php
@@ -8,9 +8,13 @@
 
 require_once __DIR__ . '/config.php';
 
-$apiId = getenv('FANZA_API_ID') ?: '47sPXfBnNCUgVfKabDPy';
+$apiId = getenv('FANZA_API_ID');
 $affiliateId = getenv('FANZA_AFFILIATE_ID');
 
+if (!$apiId) {
+    batchLog('ERROR: FANZA_API_ID が設定されていません。.envを確認してください。');
+    exit(1);
+}
 if (!$affiliateId) {
     batchLog('ERROR: FANZA_AFFILIATE_ID が設定されていません。.envを確認してください。');
     exit(1);

--- a/meikan/batch/fetch_fanza.php
+++ b/meikan/batch/fetch_fanza.php
@@ -6,9 +6,13 @@
 
 require_once __DIR__ . '/config.php';
 
-$apiId = getenv('FANZA_API_ID') ?: '47sPXfBnNCUgVfKabDPy';
+$apiId = getenv('FANZA_API_ID');
 $affiliateId = getenv('FANZA_AFFILIATE_ID');
 
+if (!$apiId) {
+    batchLog('ERROR: FANZA_API_ID が設定されていません。.envを確認してください。');
+    exit(1);
+}
 if (!$affiliateId) {
     batchLog('ERROR: FANZA_AFFILIATE_ID が設定されていません。.envを確認してください。');
     exit(1);


### PR DESCRIPTION
## Summary
- GitGuardianで検出された「Generic Database Assignment」シークレット漏洩への対応
- `fetch_fanza.php` / `fetch_actress_profiles.php` からFANZA API IDのフォールバック値（`47sPXfBnNCUgVfKabDPy`）を削除し、環境変数未設定時はエラー終了するように変更
- `.env.example` と `docs/deploy.md` の実API IDをプレースホルダーに置換

## ⚠️ 重要: マージ後にやること
- **FANZA API IDを無効化して再発行してください**（Git履歴に残っているため、コードから消すだけでは不十分です）
- 本番サーバーの `.env` に新しいAPI IDを設定してください

## Test plan
- [ ] `php batch/fetch_fanza.php` が `.env` にAPI IDがある状態で正常動作すること
- [ ] `.env` からAPI IDを消した状態でエラーメッセージが出ること

https://claude.ai/code/session_01YR8r8knFLcCWhXt78KV3Pn