### PR TITLE
docs: 競合8社の参照ドメイン横断比較結果を追加

### DIFF
--- a/.claude/skills/research-backlink-competitors/SKILL.md
+++ b/.claude/skills/research-backlink-competitors/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: research-backlink-competitors
+description: "競合サイトの参照ドメインをAhrefs MCPで横断調査し、被リンク獲得候補を抽出する。'被リンク調査', '参照ドメイン調査', 'バックリンク候補', 'refdomain比較', 'リンク獲得候補抽出', 'competitor backlink research'で発動。"
+metadata:
+  version: 1.0.0
+---
+
+# 競合参照ドメイン横断調査スキル
+
+オーガニック競合の参照ドメインをAhrefs MCPで取得し、複数競合に共通して掲載されるドメインや、1社のみだが獲得可能性のあるドメインをリストアップして `docs/` に格納する。
+
+---
+
+## 前提
+
+- Ahrefs MCPサーバー（`d05d162a-...`）が有効
+- av-hakase.com はAhrefsプロジェクトにGSC連携されていない可能性あり → `site-explorer-*` 系で代替する
+- 結果は `docs/` 配下にMarkdownで保存し、`docs/backlink-outreach.md` への追加候補として活用する
+
+---
+
+## Step 1: 競合サイトの特定（5〜8社）
+
+すでに `docs/competitor-refdomain-research-plan.md` で5社が選定済みの場合はそれを使う。新規の場合は以下を実行:
+
+```
+mcp__d05d162a-...-site-explorer-organic-competitors
+  target=av-hakase.com
+  mode=subdomains
+  country=jp
+  date=<実行日 YYYY-MM-DD>
+  limit=30
+  order_by=keywords_common:desc
+  select=competitor_domain,keywords_common,keywords_competitor,keywords_target,traffic,domain_rating
+```
+
+抽出時は **直接競合（女優DB／ジャンル特化）** を優先し、以下は除外する:
+- メーカー公式（dmm.co.jp, sod.co.jp, mgstage.com）
+- Tubeサイト（njavtv.com, tktube.com）
+- ノイズ（hitomi.la — コミック検索, fmk.fm — 音楽, fanbox.cc）
+
+---
+
+## Step 2: 各競合の参照ドメイン取得
+
+選定した5〜8社に対して **並列で** 以下を実行（1メッセージで複数tool callを送る）:
+
+```
+mcp__d05d162a-...-site-explorer-referring-domains
+  target=<competitor_domain>
+  mode=subdomains
+  history=live
+  limit=100
+  order_by=domain_rating:desc
+  select=domain,domain_rating,traffic_domain,dofollow_links,links_to_target
+  where={"and":[
+    {"field":"is_root_domain","is":["eq",true]},
+    {"field":"is_spam","is":["eq",false]},
+    {"field":"dofollow_links","is":["gt",0]}
+  ]}
+```
+
+**重要**: `where`句で `is_spam=false` と `dofollow_links>0` を必ず指定。これでスパム/nofollowを事前に除外する。
+
+コスト目安: 約16 units/row × 100 × 8社 = 約12,800 units（実際は競合ごとに参照ドメイン数が異なるため変動）
+
+---
+
+## Step 3: 横断比較（2サイト以上で出現するドメイン抽出）
+
+各競合の結果からドメインリストを作成し、出現サイト数をカウント。
+
+優先度判定基準:
+
+| 出現数 | DR | 判定 |
+|--------|----|----|
+| 4社以上 | 任意 | ★★★ 最優先 |
+| 2-3社 | DR50+ | ★★★ |
+| 2-3社 | DR30-49 | ★★ |
+| 2-3社 | DR10-29 | ★ |
+| 2-3社 | DR0-9 | ★（連絡コスト次第） |
+
+**× 除外推奨パターン:**
+- `.info` 連番ドメイン（rttrws*, q3bbpj*, lmcuppg* 等）→ PBNネットワーク
+- ドメイン名が乱文（tatougsggd.com, healingisland3103.com 等）
+- 中華圏（`.cc`, 数字+xyz 等）でAV系コンテンツの怪しいもの
+
+---
+
+## Step 4: 1サイトのみだが「出せそう」な候補抽出
+
+すべての競合の参照ドメインから、出現は1サイトのみだが以下の条件を満たすものをTier分類する。
+
+| Tier | 条件 | 取得方法 |
+|-----|------|---------|
+| **S** | DR60+ かつ申請ベースで自社で獲得可能 | 自社オペで獲得（ameblo.jp 投稿、megalodon.jp アーカイブ申請、ランキングサイト登録 等） |
+| **A** | DR40-59 のメディア系 | プレスリリース・寄稿打診・問い合わせフォーム |
+| **B** | DR20-39 の個人ブログ・小規模メディア | 連絡可能性を個別調査 |
+| **C** | DR0-19 の個人ブログ | 連絡コスト最小、ついで枠 |
+
+**抽出対象に含める基準:**
+- AV/風俗/グラビア関連のテーマ親和性あり
+- 連絡フォーム・問い合わせ手段がありそう
+- ドメイン名・コンテンツ内容が真っ当
+
+**含めない:**
+- 中華・韓国系（言語の壁）
+- 競合自身（pan-pan.co, minnano-av.com 等）
+- PBN疑い
+
+---
+
+## Step 5: ドキュメント化
+
+`docs/competitor-refdomain-findings.md` に以下の構造で保存（既存の場合は日付セクションで追記）:
+
+```markdown
+# 競合参照ドメイン調査 結果（YYYY-MM-DD Ahrefs実行）
+
+## 調査対象（オーガニック競合N社）
+<テーブル: ドメイン, DR, タイプ, 共通KW>
+
+## 1. 2サイト以上で参照されるドメイン（N件）
+### ★★★ 最優先候補
+### ★★ 中優先
+### ★ 小優先
+### × 除外推奨（PBN/低品質）
+
+## 2. 1サイトのみだが「出せそう」な候補
+### Tier S：自社獲得可能（DR60+）
+### Tier A：個別連絡で獲得余地（DR40-59）
+### Tier B：個人ブログ・小規模メディア（DR20-39）
+### Tier C：個人ブログ（DR0-19）
+### × 除外
+
+## 3. 次アクション
+1. Tier S/A から優先的に20件程度を docs/backlink-outreach.md に追加
+2. 最頻出ドメインのリンクパターン調査
+3. PBN系の自社被リンク確認（disavow判断）
+
+## 付録：データ取得コマンド
+```
+
+---
+
+## Step 6: コミット & PR
+
+```bash
+git checkout -b claude/refdomain-research-YYYYMMDD  # または既存の作業ブランチで
+git add docs/competitor-refdomain-findings.md
+git commit -m "docs/competitor-refdomain-findings.md: 競合N社の参照ドメイン横断比較結果"
+git push -u origin <branch>
+# mcp__github__create_pull_request でPR作成
+```
+
+PR本文には以下を含める:
+- 調査対象の競合数とドメイン
+- 抽出された★★★ドメインの代表例
+- Tier S/A の代表例
+- 次アクション
+
+---
+
+## トラブルシューティング
+
+### `where` フィルタで InputValidationError
+
+- `not_substring` は無効。`{"not":{"field":"x","is":["substring","val"]}}` のように `not` で囲む
+- URL型フィールドへの `substring` は値の型エラー → 部分URLは渡せない。`prefix` で完全URL指定する
+
+### `select` で column not found
+
+- 各エンドポイントの `select` 識別子は doc tool の `outputSchema` で確認（`where` の column識別子とは別物）
+- 例: organic-competitors は `keywords_common`, `keywords_competitor`, `traffic`, `domain_rating` を使う（`common_keywords` は誤り）
+
+### コスト超過
+
+- `select` から `traffic_value`, `org_cost`, `paid_cost`, `refdomains`, `dofollow_refdomains` 等の高ユニット列を外す
+- `limit` を50に絞る
+- 競合数を5社に絞る（最重要）
+
+---
+
+## このスキルが使われた事例
+
+- 2026-05-01: `docs/competitor-refdomain-findings.md` を作成。8社調査で2サイト以上出現39件、1サイト候補38件を抽出。PR #16

--- a/docs/competitor-refdomain-findings.md
+++ b/docs/competitor-refdomain-findings.md
@@ -1,0 +1,168 @@
+# 競合参照ドメイン調査 結果（2026-05-01 Ahrefs実行）
+
+`docs/competitor-refdomain-research-plan.md` のStep 2-3を実行した結果。
+av-hakase.com のオーガニック競合8サイトの参照ドメインを横断比較し、被リンク獲得候補を抽出。
+
+- 実行日: 2026-05-01
+- データソース: Ahrefs site-explorer-referring-domains（mode=subdomains, history=live, dofollow_links>0, is_spam=false）
+- 上位100件×8サイト=計約350ユニーク参照ドメインを比較
+
+## 調査対象（オーガニック競合8サイト）
+
+| ドメイン | DR | タイプ | 共通KW（vs av-hakase） |
+|---------|----|----|---|
+| pan-pan.co | 36 | 女優プロフィールDB | 12 |
+| minnano-av.com | 37 | 国内最大級女優DB | 9 |
+| gravurefit.com | 12 | グラビア/女優まとめ | 15 |
+| av-league.com | 6 | AVランキング | 6 |
+| hairy-pedia.com | 22 | ジャンル特化（剛毛） | 5 |
+| chikubi.jp | 18 | ジャンル特化（乳首） | 2 |
+| bi-av.com | 27 | ジャンル特化（美熟女） | 2 |
+| jk-avlabo.com | 20 | ジャンル特化（JK） | 3 |
+
+---
+
+## 1. 2サイト以上で参照されるドメイン（39件）
+
+優先度：★★★ 取得効果大 / ★★ 中 / ★ 小 / × 除外推奨
+
+### ★★★ 最優先候補
+
+| ドメイン | 出現サイト数 | DR | 月トラフィック | タイプ | メモ |
+|---------|---|----|---|----|----|
+| grokipedia.com | **5** | 77 | 551,582 | Wiki型百科 | 全競合に出現。AI生成女優プロフィールから自動リンクされている可能性。要パターン調査 |
+| theporndude.com | 2 | 81 | 44,758,164 | ポルノサイトディレクトリ | 巨大ディレクトリ。掲載申請可能 |
+| boobpedia.com | 2 | 56 | 291,227 | 英語AV女優Wiki | 英語圏Wiki。プロフィール拡充で被リンク化可 |
+| girlschannel.net | 2 | 63 | 558,564 | 女性向け掲示板 | スレッド内で言及形式。ブランドメンション獲得余地 |
+| elog-ch.com | **4** | 32 | 13,178 | AV評価メディア | 4社全部に貼られている＝定番リンク先。要関係構築 |
+| av-sommelier.online | **4** | 30 | 12 | AV個人ブログ（ソムリエ） | 流入12と低いがリンク獲得実績あり。連絡可能性高い |
+| youskbe.com | 3 | 39 | 19,910 | AV評価まとめ | 3社掲載。実績ある中堅メディア |
+| avcollectors.com | 3 | 21 | 39,389 | AVコレクターDB | 女優DB系で同レイヤー。相互リンク交渉可 |
+
+### ★★ 中優先
+
+| ドメイン | 出現サイト数 | DR | 月トラフィック | タイプ |
+|---------|---|----|---|----|
+| japaneseclass.jp | 3 | 53 | 57 | 日本語学習サイト |
+| hilive.tv | 3 | 7 | 6,026 | AV視聴サービス |
+| fivestarpornsites.com | 2 | 45 | 512 | AVサイトランキング |
+| fuzoku-move.net | 2 | 45 | 46,865 | 風俗情報 |
+| smjp.jp | 2 | 28 | 1,275 | SM/マニアックまとめ |
+| mostpopularpornsites.com | 2 | 35 | 2,290 | AVサイトランキング |
+| mimizun.com | 2 | 39 | 39 | 2chアーカイブ |
+| tokyonightstyle.com | 2 | 32 | 15,340 | AVレビュー |
+| zenra.net | 2 | 31 | 14,104 | AVトレンドサイト |
+| erosugidaro.com | 2 | 22 | 2 | AV個人ブログ |
+| taitsu-ero.com | 2 | 30 | 252 | AV個人ブログ |
+| paipai-only.com | 2 | 29 | 38 | パイパイ特化個人ブログ |
+| actenter.com | 2 | 15 | 701 | AVタレント事務所 |
+
+### ★ 小優先（低DR・関係構築コスト要検討）
+
+erogotoshi.com (DR1.6, 3社), 45rina.com (DR16, 2社), minnanogo.com (DR28, 2社), movilhentai.com (DR22, 2社), girlxinh.net (DR11, 2社), shiofukikantei.com (DR16, 2社), okantobokublog.com (DR15, 2社), oshirifechi.com (DR13, 2社), north-plus.net (DR10, 2社), ingo-av-review.com (DR0, 2社)
+
+### × 除外推奨（PBN/低品質ネットワーク疑い）
+
+複数サイトに出現するも被リンクペナルティリスクのため除外:
+
+- `.info` ドメイン群: rttrws20.info, rre88trws17.info, rttrws6.info（minnano-av系で大量検出 → 同一PBN）
+- 内容希薄系: lumpy-tv.site, eroslolita.com, non-mosaic.com, healingisland3103.com, tokyotrendnews2023.com, tatougsggd.com（DR31だがドメイン名が乱文＝買収PBNの典型）
+
+→ av-hakase.com 自身がこれらから被リンクされた場合は **disavow検討** が必要。
+
+### — 競合自身（取得対象外）
+
+pan-pan.co（minnano-av/bi-avから相互参照あり）
+
+---
+
+## 2. 1サイトのみだが「出せそう」な候補
+
+DR・連絡導線・av-hakase.com とのテーマ親和性で抽出。
+
+### Tier S：申請ベースで自分達の手で獲得可能（DR60+）
+
+| ドメイン | DR | 月トラフィック | 出現先 | 取得方法 |
+|---------|----|---|----|----|
+| ameblo.jp | 93 | 20,716,346 | pan-pan | 自社で記事投稿（誰でも書ける）。プロフィールリンク |
+| adultblogranking.com | 80 | 10,404 | jk-avlabo | アダルトブログランキング登録（自動承認） |
+| megalodon.jp | 65 | 35,268 | minnano-av | Webアーカイブに自社ページを保存申請 |
+| av-event.jp | 64 | 97,960 | bi-av | AVイベント情報メディア。プレスリリース・寄稿打診 |
+
+### Tier A：個別連絡で獲得余地あり（DR40-59）
+
+| ドメイン | DR | 月トラフィック | 出現先 | タイプ | メモ |
+|---------|----|---|----|----|----|
+| sfunhk.com | 78 | 116,039 | bi-av | 香港メディア | 言語の壁あり。難易度高 |
+| wakust.com | 59 | 72,132 | jk-avlabo | AV関連メディア | 連絡可能性高い |
+| fuzokudx.com | 59 | 300,069 | av-league | 風俗DX | 関連メディア。問い合わせ可 |
+| tekoki-fuzoku-joho.com | 54 | 28,992 | chikubi | 風俗情報 | ニッチ親和 |
+| sniper.jp | 52 | 344 | bi-av | ニュースメディア | プレスリリース系 |
+| myavok.com | 51 | 1,518 | bi-av | AV情報 | 60リンク貼ってる＝積極的 |
+| limbopro.com | 51 | 1,753 | bi-av | AV関連 | 582リンク貼ってる |
+| jav.guru | 49 | 4,813,322 | minnano-av | JAVデータベース | 巨大DB。掲載申請 |
+| r18-hikaku.com | 45 | 1,667 | jk-avlabo | AVサイト比較 | 比較メディア |
+| thenude.com | 44 | 29,478 | minnano-av | 英語AVヌードDB | 英語圏 |
+
+### Tier B：個人ブログ・小規模メディア（DR20-39、連絡しやすい）
+
+| ドメイン | DR | 月トラフィック | 出現先 | タイプ |
+|---------|----|---|----|----|
+| chijolog.com | 34 | 1,670 | chikubi | 痴女特化（av-hakaseの主力ジャンル） |
+| ntr-magazine.com | 32 | 16 | jk-avlabo | NTR特化 |
+| mujiqlo.jp | 32 | 180 | chikubi | AV関連 |
+| hdouga.com | 32 | 525 | bi-av | AV動画情報（198リンク貼り） |
+| cmore.jp | 32 | 7,304 | bi-av | AV関連 |
+| e-nobunaga.com | 35 | 3,361 | bi-av | AV関連（43リンク貼り） |
+| 2chav.com | 29 | 71,376 | minnano-av | 2chまとめ |
+| imashun-navi.com | 29 | 451 | pan-pan | 風俗ナビ |
+| hamejio.com | 27 | 75 | jk-avlabo | AV関連 |
+| adult-vr072.net | 27 | 11,405 | pan-pan | VR系 |
+| pailove.tokyo | 26 | 16,818 | hairy-pedia | おっぱい特化 |
+| mazotown.info | 26 | 410 | pan-pan | マニアック系 |
+| iinee-news.com | 26 | 87 | pan-pan | ニュース系 |
+| adultsommelier.xyz | 25 | 539 | jk-avlabo | AVソムリエ |
+| erokkuma.net | 23 | 143 | jk-avlabo | AV関連 |
+| kairaku-no-numa.com | 22 | 62 | jk-avlabo | AV関連（227リンク貼り） |
+| night-life.tokyo | 21 | 5,895 | pan-pan | 夜遊びメディア |
+
+### Tier C：個人ブログ（DR一桁〜10台、連絡コスト最小）
+
+harineta.com (DR15, 2,403リンク貼り), chorosugi.com (DR4.6, 194リンク貼り), avbase.net (DR6), aiav.news (DR0), ando-shokai.com (DR1.7), sugoi-vr.org (DR9), volstar-official.jp (DR11)
+
+→ いずれも av-hakase.com クラスのサイトを掲載してくれる可能性あり。連絡フォーム調査要。
+
+### × 除外（1サイトのみだが質に難）
+
+- `.cc` `.xyz` `.info` 中華圏・PBN系（minnano-avに大量被リンクされている `141jj.com`, `5278.cc`, `520cc.cc`, `fanqianglu.com` 等）
+- 競合自身: pan-pan.co, minnano-av.com（リスト内で相互参照あるが含めない）
+
+---
+
+## 3. 次アクション
+
+1. **本一覧から `docs/backlink-outreach.md` への候補追加** — Tier S/A から優先的に20件程度を連絡先調査
+2. **grokipedia.com のリンクパターン調査** — 5社全部に貼られている＝AI/ボット系の構造的リンク獲得が可能か検証
+3. **ジャンル特化サイト（chijolog.com, hairy-pediaが貼られている個人ブログ群）への打診** — av-hakase.com の主力ジャンル（剛毛・乳首・痴女）と直接マッチ
+4. **PBN系の自社被リンク確認** — `.info` ネットワークが av-hakase.com にも貼られていないかチェック（disavow判断）
+
+## 付録：データ取得コマンド
+
+各競合サイトに対して以下のAhrefs APIを実行（限度設定で予算最適化）:
+
+```
+site-explorer-referring-domains
+  target=<competitor_domain>
+  mode=subdomains
+  history=live
+  limit=100
+  order_by=domain_rating:desc
+  select=domain,domain_rating,traffic_domain,dofollow_links,links_to_target
+  where={"and":[
+    {"field":"is_root_domain","is":["eq",true]},
+    {"field":"is_spam","is":["eq",false]},
+    {"field":"dofollow_links","is":["gt",0]}
+  ]}
+```
+
+総コスト: 約5,700 units（8サイト合計）


### PR DESCRIPTION
## Summary

`docs/competitor-refdomain-research-plan.md` のStep 2-3を実行した結果をドキュメント化。

Ahrefs `site-explorer-referring-domains` で av-hakase.com のオーガニック競合8サイト（pan-pan.co, minnano-av.com, gravurefit.com, av-league.com, hairy-pedia.com, chikubi.jp, bi-av.com, jk-avlabo.com）の参照ドメインを取得し、横断比較。

### 含まれるリスト

- **2サイト以上で参照されるドメイン（39件）** — 優先度★★★〜×除外で分類
  - 最優先（★★★）: grokipedia.com（5社全部）、theporndude.com、boobpedia.com、girlschannel.net、elog-ch.com（4社）、av-sommelier.online（4社）、youskbe.com、avcollectors.com
  - PBN疑い除外: `.info`ドメイン群（rttrws系）、tatougsggd.com、healingisland3103.com 等
- **1サイトのみだが「出せそう」な候補** — Tier S/A/B/C で分類
  - Tier S（自社で獲得可能）: ameblo.jp、adultblogranking.com、megalodon.jp、av-event.jp
  - Tier A（DR40-59、要連絡）: jav.guru、wakust.com、fuzokudx.com、sniper.jp 等
  - Tier B（DR20-39、個人ブログ系）: chijolog.com、pailove.tokyo、night-life.tokyo 等

### 次アクション

1. Tier S/A から優先的に20件程度を `docs/backlink-outreach.md` に追加
2. grokipedia.com のリンクパターン調査（5社全部に貼られている＝構造的取得が可能か）
3. PBN系ドメインが av-hakase.com 自身に貼られていないかチェック（disavow判断）

## Test plan

- [x] ドキュメントのみの追加でコード変更なし
- [x] Markdown表のレンダリング確認

https://claude.ai/code/session_015ESz29a2CnCMJo3Vx4tN3k

---
_Generated by [Claude Code](https://claude.ai/code/session_015ESz29a2CnCMJo3Vx4tN3k)_