### PR TITLE
fix(article): 内部リンクの nofollow を撤去（自ドメイン判定）

### DIFF
--- a/meikan/src/controllers/ArticleController.php
+++ b/meikan/src/controllers/ArticleController.php
@@ -837,6 +837,15 @@ class ArticleController
         return 'https://al.dmm.co.jp/?lurl=' . urlencode($directUrl) . '&af_id=' . $affiliateId . '&ch=toolbar&ch_id=text';
     }
 
+    private static function isInternalUrl(string $url): bool
+    {
+        if ($url === '') return false;
+        if ($url[0] === '#' || $url[0] === '/') return true;
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!$host) return false;
+        return $host === 'av-hakase.com' || str_ends_with($host, '.av-hakase.com');
+    }
+
     private static function inlineFormat(string $text): string
     {
         // !img[url] → インライン画像を先に抽出して保護
@@ -850,14 +859,18 @@ class ArticleController
         // [btn text](url) → ボタンリンク（先に処理）
         $text = preg_replace_callback('/\[btn ([^\]]+)\]\(([^)]+)\)/', function ($m) use (&$links) {
             $key = '%%LINK' . count($links) . '%%';
-            $links[$key] = '<a href="' . h($m[2]) . '" class="article-btn" target="_blank" rel="nofollow noopener">' . h($m[1]) . '</a>';
+            $url = $m[2];
+            $attrs = self::isInternalUrl($url) ? '' : ' target="_blank" rel="nofollow noopener"';
+            $links[$key] = '<a href="' . h($url) . '" class="article-btn"' . $attrs . '>' . h($m[1]) . '</a>';
             return $key;
         }, $text);
 
         // [text](url) → リンクを先に抽出して保護
         $text = preg_replace_callback('/\[(.+?)\]\((.+?)\)/', function ($m) use (&$links) {
             $key = '%%LINK' . count($links) . '%%';
-            $links[$key] = '<a href="' . h($m[2]) . '" target="_blank" rel="nofollow noopener">' . h($m[1]) . '</a>';
+            $url = $m[2];
+            $attrs = self::isInternalUrl($url) ? '' : ' target="_blank" rel="nofollow noopener"';
+            $links[$key] = '<a href="' . h($url) . '"' . $attrs . '>' . h($m[1]) . '</a>';
             return $key;
         }, $text);
 


### PR DESCRIPTION
## Summary
- `ArticleController::inlineFormat` が記事 Markdown 内の `[text](url)` / `[btn ...](url)` 全件に `target=\"_blank\" rel=\"nofollow noopener\"` を一律付与していた問題を修正。
- `isInternalUrl()` を追加し、内部リンク（`#`/`/`始まり、または `av-hakase.com` ホスト）には `rel`/`target` を付けず dofollow + same-tab で出力。
- 既存の `meikan/content/articles/**/*.md` を集計したところ、root-relative 319件 + アンカー 99件 + 自ドメイン絶対 0件、外部 3155件。**400件超の内部リンクが link equity を流せていなかった** 漏洩を解消。

## Background
2026-05-11 のリサーチ ( \`docs/sessions/2026-05-11-internal-linking-best-practices.md\` 表 #1, #16 ) で「最大の link equity leak」と指摘した致命対応の **#1**。Ahrefs / Cyrus Shepard の双方が「内部リンクは原則 dofollow」を強調しており、特に記事間ハブリンクが nofollow 化されている状態は最優先で潰すべき。

検討メモ: \`docs/sessions/2026-05-11-internal-linking-fix-plan.md\`

## Test plan
- [x] PHP lint: `php -l meikan/src/controllers/ArticleController.php`
- [x] `isInternalUrl()` ユニットテスト相当（10ケース、すべて期待値通り）:
  - 内部判定: `/article/foo/`, `/`, `#section`, `https://av-hakase.com/x`, `https://www.av-hakase.com/x`
  - 外部判定: `https://example.com/`, `https://av-hakase.com.evil.com/x`（ホスト末尾一致だが厳密判定でブロック）, `https://dmm.co.jp/...`, `mailto:`, 空文字
- [ ] ローカルで `php -S localhost:8000 -t meikan meikan/dev-server.php` を起動し、記事ページを表示 → 内部 \`/article/...\` リンクが `rel=\"nofollow\"` を持たないこと、外部リンクは引き続き `target=\"_blank\" rel=\"nofollow noopener\"` を持つことを DevTools で確認
- [ ] 本番デプロイ後、記事 HTML をスポット確認（例: `/article/sokkuri-suzumura-airi/`）
- [ ] デプロイ後にキャッシュクリアが必要 → `php meikan/batch/clear_cache.php` 相当を本番で実行

## Notes
- DB 変更なし、テンプレ変更なし、JS/CSS 変更なし。
- 影響範囲は記事ページのレンダリングのみ。
- 既存記事に「自ドメイン内なのに nofollow を付けたい」リンクは存在しないことを確認済み（自ドメイン絶対 URL 0件、root-relative はすべて記事間/女優ページ/ジャンルページへの正常な誘導リンク）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)